### PR TITLE
profile-page-stats functionality added

### DIFF
--- a/API PILOT 1/app.py
+++ b/API PILOT 1/app.py
@@ -10,7 +10,7 @@ from geopy.distance import geodesic
 import ast
 import json
 
-from db import get_bidders,find_rooms,distance_calc,ended,get_template,get_t,get_distance,get_room_admin,save_param,add_room_member,add_room_members,update_bid, get_closing,get_hb,get_sign,get_hbidder, get_messages, get_room, get_room_members, get_rooms_for_user, get_user, is_room_admin, is_room_member, remove_room_members, save_message, save_room, save_user, update_room, get_room_details, get_active_rooms_by_id, get_historical_rooms_by_id, get_room_details_by_ids
+from db import get_bidders,find_rooms,distance_calc,ended,get_template,get_t,get_distance,get_room_admin,save_param,add_room_member,add_room_members,update_bid, get_closing,get_hb,get_sign,get_hbidder, get_messages, get_room, get_room_members, get_rooms_for_user, get_user, is_room_admin, is_room_member, remove_room_members, save_message, save_room, save_user, update_room, get_room_details, get_active_rooms_by_id, get_historical_rooms_by_id, get_room_details_by_ids, get_number_of_active_rooms_by_id, get_number_historical_rooms_by_id
 from db import JSONEncoder
 
 app = Flask(__name__)
@@ -365,6 +365,7 @@ def get_active_rooms():
 
     return JSONEncoder().encode(rooms_with_details), 200
 
+
 @app.route('/rooms/history', methods=['GET'])
 def get_history():
     """
@@ -388,6 +389,24 @@ def get_history():
     rooms_with_details = [combine_room_with_room_details(room, details_lookup[str(room['_id'])]) for room in rooms ]
     
     return JSONEncoder().encode(rooms_with_details), 200
+
+
+@app.route('/rooms/stats/<username>', methods=['GET'])
+def get_stats(username):
+    """
+    Returns the total amount of rooms a user have participated in and
+    returns the total amount of active rooms a user is participating in. 
+
+    """
+    app.logger.info("%s requesting total amount of current and historic rooms for a specific user", username)
+
+    room_ids = [room['_id']['room_id'] for room in get_rooms_for_user(username)]
+    stats = {}
+    stats['historic'] = get_number_historical_rooms_by_id(room_ids)
+    stats['active'] = get_number_of_active_rooms_by_id(room_ids)
+    
+    return JSONEncoder().encode(stats), 200
+
 
 @login_manager.user_loader
 def load_user(username):

--- a/API PILOT 1/db.py
+++ b/API PILOT 1/db.py
@@ -314,11 +314,26 @@ def get_active_rooms_by_id(room_ids):
     """
     return rooms_collection.find({ '_id': { '$in': room_ids }, 'payload.buyersign.val': '' })
 
+def get_number_of_active_rooms_by_id(room_ids):
+    """
+    Retrieves total number of active auctions by rooom ids.
+
+    By active it means that a winner has not been selected yet, however
+    the closing date may have passed
+    """
+    return rooms_collection.find({ '_id': { '$in': room_ids }, 'payload.buyersign.val': '' }).count()
+
 def get_historical_rooms_by_id(room_ids):
     """
     Retrives historical rooms by room ids. A historical room is a room which has a winner selected.
     """
     return rooms_collection.find({ '_id': { '$in': room_ids }, 'payload.buyersign.val': { '$nin': [''] } })
+
+def get_number_historical_rooms_by_id(room_ids):
+    """
+    Retrives total number of historical rooms by room ids. A historical room is a room which has a winner selected.
+    """
+    return rooms_collection.find({ '_id': { '$in': room_ids }, 'payload.buyersign.val': { '$nin': [''] } }).count()
 
 def get_room_details_by_ids(room_ids):
     """


### PR DESCRIPTION
Some new functionality added for getting the number of historic and active auctions a user have participated/participating in.

We will probably need to add functionality for retrieve the number of auctions won. 

I might have done a weird solution in the db.py file where i created two calls to MongoDB for retrieving the stats, i suspect we might be able to do it in only one call.